### PR TITLE
Fix Area Server Events

### DIFF
--- a/src/Fragment.NetSlum.Networking/Constants/OpCodes.cs
+++ b/src/Fragment.NetSlum.Networking/Constants/OpCodes.cs
@@ -255,14 +255,14 @@ DATA_SELECT_CHAR2 seems to be a 1:1 clone of the normal OPCODE_DATA_SELECT_CHAR 
     Data_AreaServerPublishDetails2Request = 0x7016,
     Data_AreaServerPublishDetails3Request = 0x7881,
     Data_AreaServerPublishDetails4Request = 0x7887,
-    Data_AreaServerPublishDetails6Request = 0x78a7,
+    Data_AreaServerDateTimeRequest = 0x78a7,
 
     Data_AreaServerPublishDetails1Success = 0x7012,
     Data_AreaServerPublishDetails2Success = 0x7017,
     Data_AreaServerPublishDetails3Success = 0x7882,
     Data_AreaServerPublishDetails4Success = 0x7888,
     Data_AreaServerPublishDetails5Success = 0x741e,
-    Data_AreaServerPublishDetails6Success = 0x78a8,
+    Data_AreaServerDateTimeSuccess = 0x78a8,
     Data_AreaServerPublishDetails7Success = 0x780d,
 
 

--- a/src/Fragment.NetSlum.Networking/Packets/Request/AreaServer/AreaServerDateTimeRequest.cs
+++ b/src/Fragment.NetSlum.Networking/Packets/Request/AreaServer/AreaServerDateTimeRequest.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Fragment.NetSlum.Core.Extensions;
+using Fragment.NetSlum.Networking.Attributes;
+using Fragment.NetSlum.Networking.Constants;
+using Fragment.NetSlum.Networking.Objects;
+using Fragment.NetSlum.Networking.Packets.Response;
+using Fragment.NetSlum.Networking.Sessions;
+using Microsoft.Extensions.Logging;
+using Fragment.NetSlum.Networking.Packets.Response.AreaServer;
+using Fragment.NetSlum.TcpServer.Extensions;
+
+namespace Fragment.NetSlum.Networking.Packets.Request.AreaServer;
+
+[FragmentPacket(MessageType.Data, OpCodes.Data_AreaServerDateTimeRequest)]
+public class AreaServerDateTimeRequest : BaseRequest
+{
+    private readonly ILogger<AreaServerIPAddressPortRequest> _logger;
+
+    public AreaServerDateTimeRequest(ILogger<AreaServerIPAddressPortRequest> logger)
+    {
+        _logger = logger;
+    }
+
+    public override ValueTask<ICollection<FragmentMessage>> GetResponse(FragmentTcpSession session, FragmentMessage request)
+    {
+        BaseResponse response = new AreaServerDateTimeResponse();
+        return SingleMessage(response.Build());
+    }
+}

--- a/src/Fragment.NetSlum.Networking/Packets/Request/AreaServer/AreaServerPublishDetailsRequest.cs
+++ b/src/Fragment.NetSlum.Networking/Packets/Request/AreaServer/AreaServerPublishDetailsRequest.cs
@@ -17,7 +17,6 @@ namespace Fragment.NetSlum.Networking.Packets.Request.AreaServer;
 [FragmentPacket(MessageType.Data, OpCodes.Data_AreaServerPublishDetails2Request)]
 [FragmentPacket(MessageType.Data, OpCodes.Data_AreaServerPublishDetails3Request)]
 [FragmentPacket(MessageType.Data, OpCodes.Data_AreaServerPublishDetails4Request)]
-[FragmentPacket(MessageType.Data, OpCodes.Data_AreaServerPublishDetails6Request)]
 public class AreaServerPublishDetailsRequest:BaseRequest
 {
     private readonly FragmentContext _database;
@@ -70,8 +69,6 @@ public class AreaServerPublishDetailsRequest:BaseRequest
                     ]
                 };
                 break;
-            case OpCodes.Data_AreaServerPublishDetails6Request:
-                //response = new AreaServerPublishDetailsResponse() { PacketType = OpCodes.Data_AreaServerPublishDetails6Success, Data = new byte[] { 0x00, 0x09 } };
             default:
                 return NoResponse();
         }

--- a/src/Fragment.NetSlum.Networking/Packets/Response/AreaServer/AreaServerDateTimeResponse.cs
+++ b/src/Fragment.NetSlum.Networking/Packets/Response/AreaServer/AreaServerDateTimeResponse.cs
@@ -1,0 +1,25 @@
+using Fragment.NetSlum.Core.Buffers;
+using Fragment.NetSlum.Core.Extensions;
+using Fragment.NetSlum.Networking.Constants;
+using Fragment.NetSlum.Networking.Objects;
+using System;
+using System.Buffers.Binary;
+
+namespace Fragment.NetSlum.Networking.Packets.Response.AreaServer;
+
+public class AreaServerDateTimeResponse : BaseResponse
+{
+    public override FragmentMessage Build()
+    {
+        var writer = new MemoryWriter(8);
+        writer.Write((uint)0);
+        writer.Write((uint)DateTime.UtcNow.ToEpoch());
+
+        return new FragmentMessage
+        {
+            MessageType = MessageType.Data,
+            DataPacketType = OpCodes.Data_AreaServerDateTimeSuccess,
+            Data = writer.Buffer,
+        };
+    }
+}


### PR DESCRIPTION
Back in the day we did the minimal amount of work needed to get the Area Servers online, and never went back to investigate the packets. As a result the Events never worked properly.  Turns out we were missing one packet with the Lobby Server DateTime.

Events should work as intended.