### PR TITLE
Fix Area Server Events running independently

### DIFF
--- a/src/Fragment.NetSlum.Networking/OnlineEvents/EventData.cs
+++ b/src/Fragment.NetSlum.Networking/OnlineEvents/EventData.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fragment.NetSlum.Networking.OnlineEvents
+{
+    public class EventData
+    {
+        // List of events with updated date ranges
+        public static List<Event> Events = new List<Event>
+        {
+            new Event { Name = "Christmas", StartDate = new DateTime(2005, 12, 24), EndDate = new DateTime(2005, 12, 25) },
+            new Event { Name = "New Years Eve", StartDate = new DateTime(2005, 12, 30), EndDate = new DateTime(2005, 12, 31) },
+            new Event { Name = "New Years Day", StartDate = new DateTime(2006, 01, 01), EndDate = new DateTime(2006, 01, 02) },
+            new Event { Name = "Setsubun", StartDate = new DateTime(2006, 02, 03), EndDate = new DateTime(2006, 02, 03) },
+            new Event { Name = "Valentine's Day", StartDate = new DateTime(2006, 02, 13), EndDate = new DateTime(2006, 02, 13) },
+            new Event { Name = "Cherry Blossom", StartDate = new DateTime(2006, 03, 15), EndDate = new DateTime(2006, 03, 15) },
+            new Event { Name = "Star Festival", StartDate = new DateTime(2006, 07, 07), EndDate = new DateTime(2006, 07, 07) }, // Tanabata
+            new Event { Name = "Obon", StartDate = new DateTime(2006, 08, 13), EndDate = new DateTime(2006, 08, 15) },
+            new Event { Name = "PC Day", StartDate = new DateTime(2006, 09, 29), EndDate = new DateTime(2006, 09, 29) },
+            new Event { Name = "Sports Day", StartDate = new DateTime(2006, 10, 09), EndDate = new DateTime(2006, 10, 09) }
+        };
+
+        public class Event
+        {
+            public string? Name { get; set; }
+            public DateTime StartDate { get; set; }
+            public DateTime? EndDate { get; set; } // Nullable in case the event is a single day
+        }
+    }
+}

--- a/src/Fragment.NetSlum.Networking/Packets/Response/AreaServer/AreaServerDateTimeResponse.cs
+++ b/src/Fragment.NetSlum.Networking/Packets/Response/AreaServer/AreaServerDateTimeResponse.cs
@@ -2,23 +2,56 @@ using Fragment.NetSlum.Core.Buffers;
 using Fragment.NetSlum.Core.Extensions;
 using Fragment.NetSlum.Networking.Constants;
 using Fragment.NetSlum.Networking.Objects;
+using Fragment.NetSlum.Networking.OnlineEvents;
 using System;
+using System.Buffers.Binary;
+using System.Linq;
 
-namespace Fragment.NetSlum.Networking.Packets.Response.AreaServer;
-
-public class AreaServerDateTimeResponse : BaseResponse
+namespace Fragment.NetSlum.Networking.Packets.Response.AreaServer
 {
-    public override FragmentMessage Build()
+    /// <summary>
+    /// Handles the response sent to the AreaServer containing the current date or an event-specific date.
+    /// </summary>
+    public class AreaServerDateTimeResponse : BaseResponse
     {
-        var writer = new MemoryWriter(8);
-        writer.Write((uint)0);
-        writer.Write((uint)DateTime.UtcNow.ToEpoch());
-
-        return new FragmentMessage
+        /// <summary>
+        /// Builds the response packet to send the date information to the AreaServer.
+        /// </summary>
+        /// <returns>A FragmentMessage containing the appropriate date.</returns>
+        public override FragmentMessage Build()
         {
-            MessageType = MessageType.Data,
-            DataPacketType = OpCodes.Data_AreaServerDateTimeSuccess,
-            Data = writer.Buffer,
-        };
+            // Initialize the buffer to write the date information (8 bytes total).
+            var writer = new MemoryWriter(8);
+
+            // Write a placeholder value (0) to the first 4 bytes of the buffer.
+            writer.Write((uint)0);
+
+            // Get the current date and time in UTC.
+            var currentDate = DateTime.UtcNow;
+
+            // Check if the current date matches any event in the predefined event list.
+            var matchingEvent = EventData.Events.FirstOrDefault(e =>
+                e.StartDate.Date <= currentDate.Date && 
+                (e.EndDate?.Date ?? e.StartDate.Date) >= currentDate.Date);
+
+            // If an event is found, use its date; otherwise, use the current date.
+            var dateToSend = matchingEvent?.StartDate ?? currentDate;
+
+            // Convert the selected date to a Unix timestamp and write it to the buffer.
+            writer.Write((uint)dateToSend.ToEpoch());
+
+            // Log the result for debugging purposes.
+            Console.WriteLine(matchingEvent != null
+                ? $"[AreaServerDateTimeResponse] Sending event date: {matchingEvent.Name} ({dateToSend})"
+                : $"[AreaServerDateTimeResponse] Sending current date: {dateToSend}");
+
+            // Return the constructed FragmentMessage with the date information.
+            return new FragmentMessage
+            {
+                MessageType = MessageType.Data,
+                DataPacketType = OpCodes.Data_AreaServerDateTimeSuccess,
+                Data = writer.Buffer,
+            };
+        }
     }
 }


### PR DESCRIPTION
Hard coded the Online Event dates. Lobby will check current date and if it matches an Online Events month and day, it will convert the date to the correct event date to allow the event to run